### PR TITLE
fix: add kwargs to simulation API reproduction

### DIFF
--- a/ebcpy/simulationapi/__init__.py
+++ b/ebcpy/simulationapi/__init__.py
@@ -514,5 +514,6 @@ class SimulationAPI:
         return save_reproduction_archive(
             title=title,
             path=path,
-            files=files
+            files=files,
+            **kwargs
         )

--- a/ebcpy/simulationapi/dymola_api.py
+++ b/ebcpy/simulationapi/dymola_api.py
@@ -836,7 +836,8 @@ class DymolaAPI(SimulationAPI):
             path: pathlib.Path = None,
             files: list = None,
             save_total_model: bool = True,
-            export_fmu: bool = True
+            export_fmu: bool = True,
+            **kwargs
     ):
         """
         Additionally to the basic reproduction, add info
@@ -929,7 +930,8 @@ class DymolaAPI(SimulationAPI):
         return super().save_for_reproduction(
             title=title,
             path=path,
-            files=files
+            files=files,
+            **kwargs
         )
 
     def _save_to_fmu(self, fail_on_error):

--- a/ebcpy/simulationapi/fmu.py
+++ b/ebcpy/simulationapi/fmu.py
@@ -394,5 +394,6 @@ class FMU_API(simulationapi.SimulationAPI):
         return super().save_for_reproduction(
             title=title,
             path=path,
-            files=files
+            files=files,
+            **kwargs
         )


### PR DESCRIPTION
Minor fix without an issue, related to #27. Forgot kwargs in function call.