### PR TITLE
79 error example e3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bin
 *.bak
 .project
 .pydevproject
+examples/results
 
 # pip install #
 #####################

--- a/ebcpy/simulationapi/dymola_api.py
+++ b/ebcpy/simulationapi/dymola_api.py
@@ -818,6 +818,13 @@ class DymolaAPI(SimulationAPI):
         packages = self.dymola.ExecuteCommand(
             'ModelManagement.Structure.AST.Misc.ClassesInPackage("")'
         )
+        if packages is None:
+            self.logger.error("Could not load packages from Dymola, using self.packages")
+            packages = []
+            for pack in self.packages:
+                pack = pathlib.Path(pack)
+                if pack.name == "package.mo":
+                    packages.append(pack.parent.name)
         valid_packages = []
         for pack in packages:
             current_package = f"modelica://{pack}/package.order"

--- a/ebcpy/utils/reproduction.py
+++ b/ebcpy/utils/reproduction.py
@@ -291,11 +291,8 @@ def _get_python_package_information(search_on_pypi: bool):
     Function to get the content of python packages installed
     as a requirement.txt format content.
     """
-    try:
-        from pip._internal.utils.misc import get_installed_distributions
-    except ImportError:  # pip<10
-        from pip import get_installed_distributions
-    installed_packages = get_installed_distributions()
+    import pkg_resources
+    installed_packages = [pack for pack in pkg_resources.working_set]
     diff_paths = []
     requirement_txt_content = []
     for package in installed_packages:

--- a/examples/e3_dymola_example.py
+++ b/examples/e3_dymola_example.py
@@ -142,7 +142,15 @@ def main(
         result_file_name="anotherResultFile"
     )
     print(result_sp_2)
-    
+
+    # Save the data for later reproduction
+    file = dym_api.save_for_reproduction(
+        title="MyDymolaStudy",
+        files=[result_sp, result_sp_2],
+        log_message="This is just an example."
+    )
+    print("ZIP-File to reproduce all this:", file)
+
     # ######################### Closing ##########################
     # Close Dymola. If you forget to do so,
     # we call this function at the exit of your script.
@@ -169,13 +177,6 @@ def main(
     plt.title("Input of CombiTimeTable 'timTab'")
     if with_plot:
         plt.show()
-    # Save the data for later reproduction
-    file = dym_api.save_for_reproduction(
-        title="MyDymolaStudy",
-        files=[result_sp, result_sp_2],
-        log_message="This is just an example."
-    )
-    print("ZIP-File to reproduce all this:", file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Solves #79, and I encountered two additional bugs.
First, during the reproduction for the DymolaAPI it is not possible to get the used Modelica packages for older Dymola versions. Now an error is logged and only the packages which were loaded with the DymolaAPI are stored.
Second, in the reproduction, the saving of the Python packages was not possible for the newest pip versions. This is now changed to the rpk_resourses package instead of using pip internals.