### PR TITLE
improve slow loading of .mat files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,3 +116,5 @@
 - v0.5.2
   - Add save options in Dymola #98
   - Add feature to postprocess mat results within the simulate function to avoid memory errors in large studies
+- v0.5.3
+  - Improve loading of mat files #150

--- a/ebcpy/__init__.py
+++ b/ebcpy/__init__.py
@@ -8,4 +8,4 @@ from .simulationapi.fmu import FMU_API
 from .optimization import Optimizer
 
 
-__version__ = '0.5.2'
+__version__ = '0.5.3'

--- a/ebcpy/modelica/simres.py
+++ b/ebcpy/modelica/simres.py
@@ -337,4 +337,11 @@ def mat_to_pandas(fname='dsres.mat',
         time_key = 'Time / s'
     else:
         time_key = 'Time'
-    return pd.DataFrame(data).set_index(time_key)
+    try:
+        time_values = data.pop(time_key)
+    except KeyError:
+        raise KeyError(f"Time column {time_key} not found in the data dictionary.")
+    t = time.time()
+    df = pd.DataFrame(data, index=time_values)
+    df.index.name = time_key
+    return df

--- a/ebcpy/modelica/simres.py
+++ b/ebcpy/modelica/simres.py
@@ -341,7 +341,6 @@ def mat_to_pandas(fname='dsres.mat',
         time_values = data.pop(time_key)
     except KeyError:
         raise KeyError(f"Time column {time_key} not found in the data dictionary.")
-    t = time.time()
     df = pd.DataFrame(data, index=time_values)
     df.index.name = time_key
     return df


### PR DESCRIPTION
Closes #149.
This improves the loading time of .mat files. In a test of one of my result files, it improved the loading time from 39.37 seconds to 10.73 seconds.